### PR TITLE
shortpath tests

### DIFF
--- a/Win32.pm
+++ b/Win32.pm
@@ -657,6 +657,24 @@ __END__
 
 Win32 - Interfaces to some Win32 API Functions
 
+=head1 CAVEATS
+
+=head2 Short Path Names
+
+There are many situations in which modern Windows systems will not have short
+path names available. Shortpath usage can be configured system-wide via the
+registry, but the default on modern systems is to configure shortpath usage per
+volume. This can be queried, but not reliably or easily.
+
+On the shell level it can be queried with C<fsutil 8dot3name query c:>, on the C
+level it can be queried with a C<FSCTL_QUERY_PERSISTENT_VOLUME_STATE> request to
+the API call C<DeviceIOControl> as described in
+L<this article|https://www.codeproject.com/Articles/304374/Query-Volume-Setting-for-State-Windows>.
+
+The Win32 module doesn't check for any of these and simply fetches short path
+names in the same manner as the Windows API call does it: The call will succeed
+but return the long name.
+
 =head1 DESCRIPTION
 
 The Win32 module contains functions to access Win32 APIs.

--- a/Win32.pm
+++ b/Win32.pm
@@ -675,6 +675,11 @@ The Win32 module doesn't check for any of these and simply fetches short path
 names in the same manner as the Windows API call does it: The call will succeed
 but return the long name.
 
+Note that volumes for which this happens won't allow C<GetANSIPathName> to
+return useful filenames for files that contain unicode characters. It relies on
+C<GetShortPathName> returning 8.3 filenames, but absent those it'll return the
+unicode filename with unicode characters replaced with question mark characters.
+
 =head1 DESCRIPTION
 
 The Win32 module contains functions to access Win32 APIs.

--- a/t/GetShortPathName.t
+++ b/t/GetShortPathName.t
@@ -12,7 +12,7 @@ Win32::CreateFile($path);
 ok(-f $path);
 
 my $short = Win32::GetShortPathName($path);
-ok($short, qr/^\S{1,8}(\.\S{1,3})?$/);
+ok(length $short);
 ok(-f $short);
 
 unlink($path);

--- a/t/Unicode.t
+++ b/t/Unicode.t
@@ -18,6 +18,11 @@ BEGIN {
 	print "1..0 # Skip: Unicode support requires Windows 2000 or later\n";
 	exit 0;
     }
+    my $short = Win32::GetShortPathName(Win32::GetCwd().'\t\ExpandEnvironmentStrings.t');
+    if(length $short > 12) {
+	print "1..0 # Skip: The current volume does't support short names\n";
+	exit 0;
+    }
 }
 
 my $home = Win32::GetCwd();


### PR DESCRIPTION
This adds documentation about the behavior of the module in regards to modern Win10 with multiple volumes attached, and makes some tests pass.

Probably wanna add notes that:

- C: (or more accurately, the windows system volume) typically has 8.3 on
- explicitly say that the ansi paths won't work with perl core functions like unlink or touch

I did consider making the ansiname function return utf8, which would be more accurate, but those still wouldn't work with the perl core functions. There's some related chatter to that happening in p5p as well, but this way we at least document issues and get the tests passing.

Thoughts?