### PR TITLE
minor fixes to 0.52_02

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,11 @@
 Revision history for the Perl extension Win32.
 
+0.52_02 [2018-11-02]
+        - added () usage croaks.
+        - Fixed a -Warray-bounds buffer overflow in LONGPATH,
+        - Fix various -Wunused warnings
+          and two -Wmaybe-uninitialized.
+
 0.52_01 [2017-11-30]
         - add missing const
 

--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for the Perl extension Win32.
 
+0.52_01 [2017-11-30]
+        - add missing const
+
 0.52    [2015-08-19]
         - minimal Windows 10 support (thanks to Joel Maslak) [PR/8]
         - refactor Windows 10 support to include ProductInfo flags

--- a/Win32.pm
+++ b/Win32.pm
@@ -8,7 +8,7 @@ package Win32;
     require DynaLoader;
 
     @ISA = qw|Exporter DynaLoader|;
-    $VERSION = '0.52';
+    $VERSION = '0.52_01';
     $XS_VERSION = $VERSION;
     $VERSION = eval $VERSION;
 

--- a/Win32.pm
+++ b/Win32.pm
@@ -8,7 +8,7 @@ package Win32;
     require DynaLoader;
 
     @ISA = qw|Exporter DynaLoader|;
-    $VERSION = '0.52_01';
+    $VERSION = '0.52_02';
     $XS_VERSION = $VERSION;
     $VERSION = eval $VERSION;
 

--- a/Win32.xs
+++ b/Win32.xs
@@ -1764,7 +1764,7 @@ PROTOTYPES: DISABLE
 
 BOOT:
 {
-    char *file = __FILE__;
+    const char *file = __FILE__;
 
     if (g_osver.dwOSVersionInfoSize == 0) {
         g_osver.dwOSVersionInfoSize = sizeof(g_osver);

--- a/longpath.inc
+++ b/longpath.inc
@@ -81,7 +81,7 @@ LONGPATH(CHAR_T *path)
 	*start = sep;
 	if (fhand != INVALID_HANDLE_VALUE) {
 	    STRLEN len = FN_STRLEN(fdata.cFileName);
-	    if ((STRLEN)(tmpbuf + sizeof(tmpbuf) - tmpstart) > len) {
+	    if ((STRLEN)(len < tmpbuf - tmpstart + sizeof(tmpbuf))) {
 		FN_STRCPY(tmpstart, fdata.cFileName);
 		tmpstart += len;
 		FindClose(fhand);


### PR DESCRIPTION
Fix various -Wunused warnings, added () usage croaks.
Fixed a -Warray-bounds buffer overflow in LONGPATH,
and two -Wmaybe-uninitialized.

add missing const