### PR TITLE
Fix tests 14,15 of GetFullPathName.t, which failed when the lib-win32…

### DIFF
--- a/t/GetFullPathName.t
+++ b/t/GetFullPathName.t
@@ -27,8 +27,8 @@ ok((Win32::GetFullPathName(substr($cwd,2)))[1], $file);
 
 ok(scalar Win32::GetFullPathName('/Foo Bar/'), substr($cwd,0,2)."\\Foo Bar\\");
 
-chdir($dir);
-ok(scalar Win32::GetFullPathName('.'), $dir);
+chdir(my $dird = $dir !~ /^[A-Z]:$/ ? $dir : "$dir\\");
+ok(scalar Win32::GetFullPathName('.'), $dird);
 
 ok((Win32::GetFullPathName($file))[0], "$dir\\");
 ok((Win32::GetFullPathName($file))[1], $file);


### PR DESCRIPTION
… package is unpacked and tested in a top level folder (e.g. P:\Win32-0.53)