### PR TITLE
Skip tests that rely upon short names if these are unavailable.

### DIFF
--- a/Win32.pm
+++ b/Win32.pm
@@ -1423,4 +1423,37 @@ DllUnregisterServer.
 
 =back
 
+=head1 CAVEATS
+
+=head2 Short Path Names
+
+There are many situations in which modern Windows systems will not have
+the L<short path name|https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#short-vs-long-names>
+(also called 8.3 or MS-DOS) alias for long file names available.
+
+Short path support can be configured system-wide via the registry,
+but the default on modern systems is to configure short path usage per
+volume. The configuration for a volume can be queried in a number of ways,
+but these may either be unreliable or require elevated (administrator)
+privileges.
+
+Typically, the configuration for a volume can be queried using the C<fsutil>
+utility, e.g. C<fsutil 8dot3name query d:>. On the C level, it can be queried
+with a C<FSCTL_QUERY_PERSISTENT_VOLUME_STATE> request to the
+C<DeviceIOControl> API call, as described in
+L<this article|https://www.codeproject.com/Articles/304374/Query-Volume-Setting-for-State-Windows>.
+However, both of these methods require administrator privileges to work.
+
+The Win32 module does not perform any per-volume check and simply fetches
+short path names in the same manner as the underlying Windows API call it
+uses: If short path names are disabled, the call will still succeed but the
+long name will actually be returned.
+
+Note that on volumes where this happens, C<GetANSIPathName> usually cannot be
+used to return useful filenames for files that contain unicode characters.
+(In code page 65001, this may still work.) Handling unicode filenames in this
+legacy manner relies upon C<GetShortPathName> returning 8.3 filenames, but
+without short name support, it will return the filename with all unicode
+characters replaced by question mark characters.
+
 =cut

--- a/t/GetShortPathName.t
+++ b/t/GetShortPathName.t
@@ -2,6 +2,16 @@ use strict;
 use Test;
 use Win32;
 
+BEGIN {
+    Win32::CreateFile("8dot3test_canary_GetShortPathName $$");
+    my $canary = Win32::GetShortPathName("8dot3test_canary_GetShortPathName $$");
+    unlink("8dot3test_canary_GetShortPathName $$");
+    if ( length $canary > 12 ) {
+        print "1..0 # Skip: The system and/or current volume is not configured to support short names.\n";
+        exit 0;        
+    }
+}
+
 my $path = "Long Path $$";
 unlink($path);
 END { unlink $path }

--- a/t/Unicode.t
+++ b/t/Unicode.t
@@ -18,6 +18,13 @@ BEGIN {
 	print "1..0 # Skip: Unicode support requires Windows 2000 or later\n";
 	exit 0;
     }
+    Win32::CreateFile("8dot3test_canary_Unicode $$");
+    my $canary = Win32::GetShortPathName("8dot3test_canary_Unicode $$");
+    unlink("8dot3test_canary_Unicode $$");
+    if ( length $canary > 12 ) {
+        print "1..0 # Skip: The system and/or current volume is not configured to support short names.\n";
+        exit 0;        
+    }
 }
 
 my $home = Win32::GetCwd();


### PR DESCRIPTION
This commit is an update to #12. It takes @wchristian's original work and adds modifications based upon the discussion under that commit.

Basically:

1. GetShortPathName.t and Unicode.t test whether the current volume supports short path names. If not, the tests in these files are skipped.
2. Additional POD in Win32.pm discusses limitations when short path names are not available.

@jandubois Is there any chance you could look this over and hopefully cut a release before the hard freeze for Perl 5.32?