### PR TITLE
implement a function checking whether symlink creation is permitted

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -33,5 +33,6 @@ my $test_requires = $ExtUtils::MakeMaker::VERSION >= 6.64
     : 'PREREQ_PM';
 
 $param{$test_requires}{'Test'} = 0;
+$param{$test_requires}{'File::Temp'} = 0;
 
 WriteMakefile(%param);

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -11,6 +11,13 @@ my %param = (
     NAME          => 'Win32',
     VERSION_FROM  => 'Win32.pm',
     INSTALLDIRS   => ($] >= 5.008004 && $] < 5.012 ? 'perl' : 'site'),
+    PREREQ_PM     => {
+        strict => 0,
+        warnings => 0,
+        vars => 0,
+        Exporter => 0,
+        DynaLoader => 0
+    }
 );
 $param{NO_META} = 1 if eval "$ExtUtils::MakeMaker::VERSION" >= 6.10_03;
 
@@ -20,5 +27,11 @@ if ($^O eq 'cygwin') {
 else {
     $param{LIBS} = ['-luserenv']
 }
+
+my $test_requires = $ExtUtils::MakeMaker::VERSION >= 6.64
+    ? 'TEST_REQUIRES'
+    : 'PREREQ_PM';
+
+$param{$test_requires}{'Test'} = 0;
 
 WriteMakefile(%param);

--- a/Win32.pm
+++ b/Win32.pm
@@ -1233,6 +1233,25 @@ information about what you can do with this address has been lost in
 the mist of time.  Use the Win32::API module instead of this deprecated
 function.
 
+=item Win32::GetProcessPrivileges([PID])
+
+Returns a reference to a hash holding the information about the privileges
+held by the specified process. The keys are privilege names, and the values
+are booleans indicating whether a given privilege is currently enabled or not.
+
+If the optional PID parameter is omitted, the function queries the current
+process.
+
+Example return value:
+
+    {
+        SeTimeZonePrivilege => 0,
+        SeShutdownPrivilege => 0,
+        SeUndockPrivilege => 0,
+        SeIncreaseWorkingSetPrivilege => 0,
+        SeChangeNotifyPrivilege => 1
+    }
+
 =item Win32::GetProductInfo(OSMAJOR, OSMINOR, SPMAJOR, SPMINOR)
 
 Retrieves the product type for the operating system on the local

--- a/Win32.pm
+++ b/Win32.pm
@@ -1304,6 +1304,11 @@ actually running with elevated privileges.  Returns C<undef>
 and prints a warning if an error occurred.  This function always
 returns 1 on Win9X.
 
+=item Win32::IsDeveloperModeEnabled()
+
+Returns true if the developer mode is currently enabled. It always returns
+false on Windows versions older than Windows 10.
+
 =item Win32::IsWinNT()
 
 [CORE] Returns non zero if the Win32 subsystem is Windows NT.

--- a/t/Privileges.t
+++ b/t/Privileges.t
@@ -1,0 +1,27 @@
+use strict;
+use warnings;
+
+use Test;
+use Win32;
+
+plan tests => 4;
+
+ok(ref(Win32::GetProcessPrivileges) eq 'HASH');
+ok(ref(Win32::GetProcessPrivileges(Win32::GetCurrentProcessId())) eq 'HASH');
+
+# All Windows PIDs are divisible by 4. It's an undocumented implementation
+# detail, but it means it's extremely unlikely that the PID below is valid.
+ok(!Win32::GetProcessPrivileges(3423237));
+
+my $whoami = `whoami /priv 2>&1`;
+my $skip = ($? == -1 || $? >> 8) ? '"whoami" command is missing' : 0;
+
+skip($skip, sub{
+    my $privs = Win32::GetProcessPrivileges();
+
+    while ($whoami =~ /^(Se\w+)/mg) {
+        return 0 unless exists $privs->{$1};
+    }
+
+    return 1;
+});

--- a/t/Privileges.t
+++ b/t/Privileges.t
@@ -4,7 +4,7 @@ use warnings;
 use Test;
 use Win32;
 
-plan tests => 4;
+plan tests => 5;
 
 ok(ref(Win32::GetProcessPrivileges) eq 'HASH');
 ok(ref(Win32::GetProcessPrivileges(Win32::GetCurrentProcessId())) eq 'HASH');
@@ -25,3 +25,8 @@ skip($skip, sub{
 
     return 1;
 });
+
+# there isn't really anything to test, we just want to make sure that the
+# function doesn't segfault
+Win32::IsDeveloperModeEnabled();
+ok(1);


### PR DESCRIPTION
Perl 5.34 will make symlink() and friends available on Windows. Unfortunately, symlink creation requires either special privileges or enabling the developer mode. Because of that, I think it would be a good idea to have a function that checks whether the current process is allowed to create symlinks. It would be especially useful in tests.

The other two functions (GetProcessPrivileges, IsDeveloperModeEnabled) were created to make IsSymlinkCreationAllowed() implementation possible, but they're useful on their own, so I made them public.