### PR TITLE
specify the calling convention for PFNRegGetValueA

### DIFF
--- a/Win32.xs
+++ b/Win32.xs
@@ -30,7 +30,7 @@ typedef int (__stdcall *PFNDllUnregisterServer)(void);
 typedef BOOL (__stdcall *PFNIsUserAnAdmin)(void);
 typedef BOOL (WINAPI *PFNGetProductInfo)(DWORD, DWORD, DWORD, DWORD, DWORD*);
 typedef void (WINAPI *PFNGetNativeSystemInfo)(LPSYSTEM_INFO lpSystemInfo);
-typedef LONG (*PFNRegGetValueA)(HKEY, LPCSTR, LPCSTR, DWORD, LPDWORD, PVOID, LPDWORD);
+typedef LONG (WINAPI *PFNRegGetValueA)(HKEY, LPCSTR, LPCSTR, DWORD, LPDWORD, PVOID, LPDWORD);
 
 #ifndef CSIDL_MYMUSIC
 #   define CSIDL_MYMUSIC              0x000D


### PR DESCRIPTION
This should fix crashes on 32-bit systems, such as this one:
http://www.cpantesters.org/cpan/report/aea51067-79ae-1014-8029-261ce9d0f34b

Strangely enough, despite using the wrong calling convention, this code
wasn't crashing with 32-bit Visual C++.