### PR TITLE
Add Win32::HttpGetFile

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -22,10 +22,10 @@ my %param = (
 $param{NO_META} = 1 if eval "$ExtUtils::MakeMaker::VERSION" >= 6.10_03;
 
 if ($^O eq 'cygwin') {
-    $param{LIBS} = ['-L/lib/w32api -lole32 -lversion -luserenv -lnetapi32']
+    $param{LIBS} = ['-L/lib/w32api -lole32 -lversion -luserenv -lnetapi32 -lwinhttp']
 }
 else {
-    $param{LIBS} = ['-luserenv']
+    $param{LIBS} = ['-luserenv -lwinhttp']
 }
 
 my $test_requires = $ExtUtils::MakeMaker::VERSION >= 6.64

--- a/Win32.pm
+++ b/Win32.pm
@@ -1472,6 +1472,12 @@ instead.
 Loads the DLL LIBRARYNAME and calls the function
 DllUnregisterServer.
 
+=item Win32::HttpGetFile(URL, FILENAME)
+
+Uses the WinHttp library to download the file specified by the URL
+parameter to the local file specified by FILENAME. Only http and https
+protocols are supported.  Authentication is not supported.
+
 =back
 
 =head1 CAVEATS

--- a/Win32.pm
+++ b/Win32.pm
@@ -1322,7 +1322,8 @@ context also returns, in addition to the boolean status, a second
 value containing message text related to the status.
 
 If the call fails, C<Win32::GetLastError()> will return a numeric
-error code, which may be either a system error or a WinHttp error.
+error code, which may be a system error, a WinHttp error, or a
+user-defined error composed of 1e9 plus the HTTP status code.
 
 Scalar context example:
 
@@ -1339,6 +1340,10 @@ List context example:
     }
     else {
         print "Failure!: $msg\n";
+        my $err = Win32::GetLastError();
+        if ($err > 1e9) {
+            printf "HTTP status: %d\n", ($err - 1e9);
+        }
     }
 
 =item Win32::InitiateSystemShutdown

--- a/Win32.pm
+++ b/Win32.pm
@@ -1305,6 +1305,14 @@ of hex digits with surrounding braces.  For example:
 
     {09531CF1-D0C7-4860-840C-1C8C8735E2AD}
 
+=item Win32::HttpGetFile(URL, FILENAME)
+
+Uses the WinHttp library to download the file specified by the URL
+parameter to the local file specified by FILENAME. Only http and https
+protocols are supported.  Authentication is not supported.  The function
+is not available when building with gcc prior to 4.8.0 because the
+winhttp library is not available.
+
 =item Win32::InitiateSystemShutdown
 
 (MACHINE, MESSAGE, TIMEOUT, FORCECLOSE, REBOOT)
@@ -1471,12 +1479,6 @@ instead.
 
 Loads the DLL LIBRARYNAME and calls the function
 DllUnregisterServer.
-
-=item Win32::HttpGetFile(URL, FILENAME)
-
-Uses the WinHttp library to download the file specified by the URL
-parameter to the local file specified by FILENAME. Only http and https
-protocols are supported.  Authentication is not supported.
 
 =back
 

--- a/Win32.pm
+++ b/Win32.pm
@@ -1305,19 +1305,47 @@ of hex digits with surrounding braces.  For example:
 
     {09531CF1-D0C7-4860-840C-1C8C8735E2AD}
 
-=item Win32::HttpGetFile(URL, FILENAME)
+=item Win32::HttpGetFile(URL, FILENAME [, IGNORE_CERT_ERRORS])
 
 Uses the WinHttp library to download the file specified by the URL
-parameter to the local file specified by FILENAME. Only http and https
-protocols are supported.  Authentication is not supported.  The function
-is not available when building with gcc prior to 4.8.0 because the
-winhttp library is not available.
+parameter to the local file specified by FILENAME. The optional third
+parameter, if true, indicates that certficate errors are to be ignored
+for https connections; please use with caution in a safe environment,
+such as when testing locally using a self-signed certificate.
+
+Only http and https protocols are supported.  Authentication is not
+supported.  The function is not available when building with gcc prior to
+4.8.0 because the WinHttp library is not available.
+
+In scalar context returns a boolean success or failure, and in list
+context also returns, in addition to the boolean status, a second
+value containing message text related to the status.
+
+If the call fails, C<Win32::GetLastError()> will return a numeric
+error code, which may be either a system error or a WinHttp error.
+
+Scalar context example:
+
+    print Win32::GetLastError()
+        unless Win32::HttpGetFile('http://example.com/somefile.tar.gz',
+                                  '.\file.tgz');
+
+List context example:
+
+    my ($ok, $msg) = Win32::HttpGetFile('http://example.com/somefile.tar.gz',
+                                        '.\file.tgz');
+    if ($ok) {
+        print "Success!: $msg\n";
+    }
+    else {
+        print "Failure!: $msg\n";
+    }
 
 =item Win32::InitiateSystemShutdown
 
 (MACHINE, MESSAGE, TIMEOUT, FORCECLOSE, REBOOT)
 
-Shutsdown the specified MACHINE, notifying users with the
+Shuts down the specified MACHINE, notifying users with the
 supplied MESSAGE, within the specified TIMEOUT interval.  Forces
 closing of all documents without prompting the user if FORCECLOSE is
 true, and reboots the machine if REBOOT is true.  This function works

--- a/Win32.xs
+++ b/Win32.xs
@@ -7,7 +7,9 @@
 #include <wchar.h>
 #include <userenv.h>
 #include <lm.h>
-#include <winhttp.h>
+#if !defined(__GNUC__) || (((100000 * __GNUC__) + (1000 * __GNUC_MINOR__)) >= 408000)
+#  include <winhttp.h>
+#endif
 
 #define PERL_NO_GET_CONTEXT
 #include "EXTERN.h"
@@ -1683,6 +1685,7 @@ XS(w32_IsDeveloperModeEnabled)
     XSRETURN_NO;
 }
 
+#ifdef WINHTTPAPI
 
 XS(w32_HttpGetFile)
 {
@@ -1902,6 +1905,8 @@ XS(w32_HttpGetFile)
     XSRETURN_YES;
 }
 
+#endif
+
 MODULE = Win32            PACKAGE = Win32
 
 PROTOTYPES: DISABLE
@@ -1976,6 +1981,8 @@ BOOT:
 #ifdef __CYGWIN__
     newXS("Win32::SetChildShowWindow", w32_SetChildShowWindow, file);
 #endif
+#ifdef WINHTTPAPI
     newXS("Win32::HttpGetFile", w32_HttpGetFile, file);
+#endif
     XSRETURN_YES;
 }

--- a/Win32.xs
+++ b/Win32.xs
@@ -1928,6 +1928,12 @@ XS(w32_HttpGetFile)
     if (bAborted)
         error = GetLastError();
 
+    /* If we successfully opened the output file but failed later, mark
+     * the file for deletion.
+     */
+    if (bAborted && hOut != INVALID_HANDLE_VALUE)
+        (void) DeleteFileW(file);
+
     /* Close any open handles. */
     if (hOut) CloseHandle(hOut);
     if (hRequest) WinHttpCloseHandle(hRequest);

--- a/Win32.xs
+++ b/Win32.xs
@@ -1697,7 +1697,7 @@ XS(w32_HttpGetFile)
     HINTERNET  hSession = NULL,
                hConnect = NULL,
                hRequest = NULL;
-    HANDLE hOut = NULL;
+    HANDLE hOut = INVALID_HANDLE_VALUE;
     BOOL   bParsed = FALSE,
            bAborted = FALSE,
            bFileError = FALSE,
@@ -1935,7 +1935,7 @@ XS(w32_HttpGetFile)
         (void) DeleteFileW(file);
 
     /* Close any open handles. */
-    if (hOut) CloseHandle(hOut);
+    if (hOut != INVALID_HANDLE_VALUE) CloseHandle(hOut);
     if (hRequest) WinHttpCloseHandle(hRequest);
     if (hConnect) WinHttpCloseHandle(hConnect);
     if (hSession) WinHttpCloseHandle(hSession);

--- a/t/HttpGetFile.t
+++ b/t/HttpGetFile.t
@@ -18,7 +18,7 @@ my $english_locale = (Win32::FormatMessage(1) eq "Incorrect function.\r\n");
 # We may not always have an internet connection, so don't
 # attempt remote connections unless the user has done
 #   set PERL_WIN32_INTERNET_OK=1
-plan tests => $ENV{PERL_WIN32_INTERNET_OK} ? 13 : 7;
+plan tests => $ENV{PERL_WIN32_INTERNET_OK} ? 19 : 7;
 
 # On Cygwin the test_harness will invoke additional Win32 APIs that
 # will reset the Win32::GetLastError() value, so capture it immediately.
@@ -82,4 +82,20 @@ if ($ENV{PERL_WIN32_INTERNET_OK}) {
     ok($sha->hexdigest,
        '9d282e2292e67fb2e25422dfb190474e30a38de3',
        "downloaded GitHub zip archive has correct digest");
+
+    ok(HttpGetFile('https://self-signed.badssl.com/index.html', 'NUL:'),
+       '',
+       'Cannot download from site with self-signed cert without ignoring cert errors');
+    ok($LastError, '12175', "correct code for ERROR_WINHTTP_SECURE_FAILURE with self-signed certificate");
+    ok(HttpGetFile('https://self-signed.badssl.com/index.html', 'NUL:', 1),
+       '1',
+       'Can download from site with self-signed cert using ignore cert errors parameter');
+
+    ok(HttpGetFile('https://expired.badssl.com/index.html', 'NUL:'),
+       '',
+       'Cannot download from site with expired cert without ignoring cert errors');
+    ok($LastError, '12175', "correct code for ERROR_WINHTTP_SECURE_FAILURE with expired certificate");
+    ok(HttpGetFile('https://expired.badssl.com/index.html', 'NUL:', 1),
+       '1',
+       'Can download from site with expired cert using ignore cert errors parameter');
 }

--- a/t/HttpGetFile.t
+++ b/t/HttpGetFile.t
@@ -3,6 +3,8 @@ use warnings;
 use Test;
 use Win32;
 use Digest::SHA;
+use POSIX qw(locale_h);
+setlocale(LC_ALL, "C"); # to make error messages predictable
 
 my $tmpfile = "http-download-test-$$.tgz";
 END { 1 while unlink $tmpfile; }
@@ -15,7 +17,7 @@ unless (defined &Win32::HttpGetFile) {
 # We may not always have an internet connection, so don't
 # attempt remote connections unless the user has done
 #   set PERL_WIN32_INTERNET_OK=1
-plan tests => $ENV{PERL_WIN32_INTERNET_OK} ? 6 : 4;
+plan tests => $ENV{PERL_WIN32_INTERNET_OK} ? 12 : 7;
 
 # On Cygwin the test_harness will invoke additional Win32 APIs that
 # will reset the Win32::GetLastError() value, so capture it immediately.
@@ -26,10 +28,21 @@ sub HttpGetFile {
     return $ok;
 }
 
+sub HttpGetFileList {
+    my ($ok, $message) = Win32::HttpGetFile(@_);
+    $LastError = Win32::GetLastError();
+    return ($ok, $message);
+}
+
 ok(HttpGetFile('nonesuch://example.com', 'NUL:'), "", "'nonesuch://' is not a real protocol");
 ok($LastError, '12006', "correct error code for unrecognized protocol");
 ok(HttpGetFile('http://!#@!&@$', 'NUL:'), "", "invalid URL");
 ok($LastError, '12005', "correct error code for invalid URL");
+
+my ($ok, $message) = HttpGetFileList('nonesuch://example.com', 'NUL:');
+ok($ok, "", "'nonesuch://' is not a real protocol");
+ok($message, "The URL does not use a recognized protocol\r\n", "correct bad protocol message");
+ok($LastError, '12006', "correct error code for unrecognized protocol with list context return");
 
 if ($ENV{PERL_WIN32_INTERNET_OK}) {
     # The digest for version 0.57 should obviously stay the same even after new versions are released
@@ -42,4 +55,13 @@ if ($ENV{PERL_WIN32_INTERNET_OK}) {
     ok($sha->hexdigest,
        '44a6d7d1607d7267b0dbcacbb745cec204f1c1a4',
        "downloaded tarball has correct digest");
+
+    my ($ok, $message) = HttpGetFileList('https://cpan.metacpan.org/authors/id/Z/ZZ/ZILCH/nonesuch.tar.gz', 'NUL:');
+    ok($ok, '', 'Download of nonexistent file from real site should fail with 404');
+    ok($message, 'Not Found', 'Should get text of 404 message');
+
+    # Since all GitHub downloads use redirects, we can test that they work.
+    ok(Win32::HttpGetFile('https://github.com/perl-libwin32/win32/archive/refs/tags/v0.57.zip', $tmpfile),
+       '1',
+       "successfully downloaded a zipball via redirect");
 }

--- a/t/HttpGetFile.t
+++ b/t/HttpGetFile.t
@@ -18,7 +18,7 @@ my $english_locale = (Win32::FormatMessage(1) eq "Incorrect function.\r\n");
 # We may not always have an internet connection, so don't
 # attempt remote connections unless the user has done
 #   set PERL_WIN32_INTERNET_OK=1
-plan tests => $ENV{PERL_WIN32_INTERNET_OK} ? 19 : 7;
+plan tests => $ENV{PERL_WIN32_INTERNET_OK} ? 20 : 7;
 
 # On Cygwin the test_harness will invoke additional Win32 APIs that
 # will reset the Win32::GetLastError() value, so capture it immediately.
@@ -64,6 +64,7 @@ if ($ENV{PERL_WIN32_INTERNET_OK}) {
 
     my ($ok, $message) = HttpGetFileList('https://cpan.metacpan.org/authors/id/Z/ZZ/ZILCH/nonesuch.tar.gz', 'NUL:');
     ok($ok, '', 'Download of nonexistent file from real site should fail with 404');
+    ok($LastError - 1e9, '404', 'Correct 404 HTTP status for not found');
     if ($english_locale) {
         ok($message, 'Not Found', 'Should get text of 404 message');
     }
@@ -76,7 +77,6 @@ if ($ENV{PERL_WIN32_INTERNET_OK}) {
        '1',
        "successfully downloaded a zipball via redirect");
 
-    $sha = undef;
     $sha = Digest::SHA->new('sha1');
     $sha->addfile($tmpfile, 'b');
     ok($sha->hexdigest,

--- a/t/HttpGetFile.t
+++ b/t/HttpGetFile.t
@@ -18,7 +18,7 @@ my $english_locale = (Win32::FormatMessage(1) eq "Incorrect function.\r\n");
 # We may not always have an internet connection, so don't
 # attempt remote connections unless the user has done
 #   set PERL_WIN32_INTERNET_OK=1
-plan tests => $ENV{PERL_WIN32_INTERNET_OK} ? 12 : 7;
+plan tests => $ENV{PERL_WIN32_INTERNET_OK} ? 13 : 7;
 
 # On Cygwin the test_harness will invoke additional Win32 APIs that
 # will reset the Win32::GetLastError() value, so capture it immediately.
@@ -71,7 +71,15 @@ if ($ENV{PERL_WIN32_INTERNET_OK}) {
         skip("Cannot verify error on non-English locale setting");
     }
     # Since all GitHub downloads use redirects, we can test that they work.
+    1 while unlink $tmpfile;
     ok(Win32::HttpGetFile('https://github.com/perl-libwin32/win32/archive/refs/tags/v0.57.zip', $tmpfile),
        '1',
        "successfully downloaded a zipball via redirect");
+
+    $sha = undef;
+    $sha = Digest::SHA->new('sha1');
+    $sha->addfile($tmpfile, 'b');
+    ok($sha->hexdigest,
+       '9d282e2292e67fb2e25422dfb190474e30a38de3',
+       "downloaded GitHub zip archive has correct digest");
 }

--- a/t/HttpGetFile.t
+++ b/t/HttpGetFile.t
@@ -1,0 +1,31 @@
+use strict;
+use warnings;
+use Test;
+use Win32;
+use Digest::SHA;
+
+my $tmpfile = "http-download-test-$$.tgz";
+END { 1 while unlink $tmpfile; }
+
+# We may not always have an internet connection, so don't
+# attempt remote connections unless the user has done
+#   set PERL_WIN32_INTERNET_OK=1
+plan tests => $ENV{PERL_WIN32_INTERNET_OK} ? 6 : 4;
+
+ok(Win32::HttpGetFile('nonesuch://example.com', 'NUL:'), "", "'nonesuch://' is not a real protocol");
+ok(Win32::GetLastError(), '12006', "correct error code for unrecognized protocol");
+ok(Win32::HttpGetFile('http://!#@!&@$', 'NUL:'), "", "invalid URL");
+ok(Win32::GetLastError(), '12005', "correct error code for invalid URL");
+
+if ($ENV{PERL_WIN32_INTERNET_OK}) {
+    # The digest for version 0.57 should obviously stay the same even after new versions are released
+    ok(Win32::HttpGetFile('https://cpan.metacpan.org/authors/id/J/JD/JDB/Win32-0.57.tar.gz', $tmpfile),
+       '1',
+       "successfully downloaded a tarball");
+
+    my $sha = Digest::SHA->new('sha1');
+    $sha->addfile($tmpfile, 'b');
+    ok($sha->hexdigest,
+       '44a6d7d1607d7267b0dbcacbb745cec204f1c1a4',
+       "downloaded tarball has correct digest");
+}

--- a/t/HttpGetFile.t
+++ b/t/HttpGetFile.t
@@ -7,6 +7,11 @@ use Digest::SHA;
 my $tmpfile = "http-download-test-$$.tgz";
 END { 1 while unlink $tmpfile; }
 
+unless (defined &Win32::HttpGetFile) {
+    print "1..0 # Skip: gcc before 4.8 does not have winhttp library\n";
+    exit;
+}
+
 # We may not always have an internet connection, so don't
 # attempt remote connections unless the user has done
 #   set PERL_WIN32_INTERNET_OK=1


### PR DESCRIPTION
Discussions around mitigating the recent CVEs against PAUSE/CPAN
(CVE-2020-16154, CVE-2020-16155, and CVE-2020-16156) included the desire
to make Perl core able to do secure downloads out of the box, and
further discussion that mechanisms based on OpenSSL, curl, or wget may
not be available on Windows.  See, for example:

https://www.nntp.perl.org/group/perl.perl5.porters/2021/12/msg262180.html

This commit adds a native download function to the Win32 module based on
the WinHttp library, a function that could in turn be used by CPAN.pm,
etc.

N.B.  The autoproxy detection code has not been tested since I don't
have a set-up where I can do that.