### PR TITLE
Use correct constant to read 64bit registry

### DIFF
--- a/Win32.xs
+++ b/Win32.xs
@@ -1667,6 +1667,10 @@ XS(w32_GetProcessPrivileges)
     XSRETURN(1);
 }
 
+#ifndef RRF_SUBKEY_WOW6464KEY
+#  define RRF_SUBKEY_WOW6464KEY 0x00010000
+#endif
+
 XS(w32_IsDeveloperModeEnabled)
 {
     dXSARGS;
@@ -1693,7 +1697,7 @@ XS(w32_IsDeveloperModeEnabled)
         HKEY_LOCAL_MACHINE,
         "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\AppModelUnlock",
         "AllowDevelopmentWithoutDevLicense",
-        RRF_RT_REG_DWORD | KEY_WOW64_64KEY,
+        RRF_RT_REG_DWORD | RRF_SUBKEY_WOW6464KEY,
         NULL,
         &val,
         &val_size

--- a/Win32.xs
+++ b/Win32.xs
@@ -102,6 +102,10 @@ typedef LONG (WINAPI *PFNRegGetValueA)(HKEY, LPCSTR, LPCSTR, DWORD, LPDWORD, PVO
 #   define CSIDL_FLAG_CREATE          0x8000
 #endif
 
+#ifndef RRF_SUBKEY_WOW6464KEY
+#  define RRF_SUBKEY_WOW6464KEY 0x00010000
+#endif
+
 /* Use explicit struct definition because wSuiteMask and
  * wProductType are not defined in the VC++ 6.0 headers.
  * WORD type has been replaced by unsigned short because
@@ -1666,10 +1670,6 @@ XS(w32_GetProcessPrivileges)
     ST(0) = sv_2mortal(newRV_noinc((SV*)priv_hv));
     XSRETURN(1);
 }
-
-#ifndef RRF_SUBKEY_WOW6464KEY
-#  define RRF_SUBKEY_WOW6464KEY 0x00010000
-#endif
 
 XS(w32_IsDeveloperModeEnabled)
 {


### PR DESCRIPTION
#37 with the preprocessor definitions moved as requested.

Fixes #36 

I'm seeing this issue in 32-bit builds of perl itself.