### PR TITLE
Allow for enabling of USE_IMP_SYS in Win32 unthreaded builds.

### DIFF
--- a/t/GetCurrentThreadId.t
+++ b/t/GetCurrentThreadId.t
@@ -3,7 +3,7 @@ use Config qw(%Config);
 use Test::More;
 use Win32;
 
-my $fork_emulation = $Config{ccflags} =~ /PERL_IMPLICIT_SYS/;
+my $fork_emulation = defined($Config{useithreads});
 
 plan tests => $fork_emulation ? 4 : 2;
 

--- a/t/GetCurrentThreadId.t
+++ b/t/GetCurrentThreadId.t
@@ -3,7 +3,9 @@ use Config qw(%Config);
 use Test::More;
 use Win32;
 
-my $fork_emulation = defined($Config{useithreads});
+# Cygwin builds set useithreads=define but use the OS's real fork(),
+# not the Win32 fork emulation — so gate on $^O as well.
+my $fork_emulation = $^O eq 'MSWin32' && ($Config{useithreads} // '') eq 'define';
 
 plan tests => $fork_emulation ? 4 : 2;
 


### PR DESCRIPTION
Enabled by merging of https://github.com/Perl/perl5/pull/23178 .
As of the merging of that PR, it is possible that an unthreaded Win32 build of perl has both USE_MULTI and USE_IMP_SYS defined.
The opening line of code in t/GetCurrentThreadId.t makes the (now) incorrect assumption that the perl is unthreaded because USE_IMP_SYS is defined.
This PR corrects that opening line by instead checking $Config{useithreads} for definedness.