### PR TITLE
Free WinHttpGetProxyForUrl strings with GlobalFree, not Safefree

### DIFF
--- a/Win32.xs
+++ b/Win32.xs
@@ -1843,8 +1843,9 @@ XS(w32_HttpGetFile)
                 bAborted = TRUE;
                 Perl_warn(aTHX_ "Win32::HttpGetFile: setting proxy options failed");
             }
-            Safefree(ProxyInfo.lpszProxy);
-            Safefree(ProxyInfo.lpszProxyBypass);
+            /* WinHttpGetProxyForUrl allocates these with GlobalAlloc. */
+            if (ProxyInfo.lpszProxy)       GlobalFree(ProxyInfo.lpszProxy);
+            if (ProxyInfo.lpszProxyBypass) GlobalFree(ProxyInfo.lpszProxyBypass);
         }
     }
 


### PR DESCRIPTION
## Summary

`WinHttpGetProxyForUrl` allocates `lpszProxy` and `lpszProxyBypass` with `GlobalAlloc` ([MSDN](https://learn.microsoft.com/en-us/windows/win32/api/winhttp/nf-winhttp-winhttpgetproxyforurl)), so they must be released with `GlobalFree`. Calling `Safefree` on them mixes allocator pools and can trigger `panic: free to wrong pool` on a debugging perl.

The proxy branch fires only when WPAD auto-detect succeeds, which is why the bug has gone unnoticed since the code landed in #30.

Spotted by @bulk88 in #44; this PR carves out just that fix.

## Test plan

- [ ] Build on Strawberry Perl and confirm `t/HttpGetFile.t` still passes
- [ ] Manual smoke with `PERL_WIN32_INTERNET_OK=1` on a network with WPAD configured (the only path that exercises the changed branch)