### PR TITLE
Handle CP_UTF8 system codepage in wstr_to_sv and my_ansipath

### DIFF
--- a/Win32.xs
+++ b/Win32.xs
@@ -159,7 +159,11 @@ wstr_to_sv(pTHX_ WCHAR *wstr)
     SV *sv = sv_2mortal(newSV(len));
 
     len = WideCharToMultiByte(CP_ACP, WC_NO_BEST_FIT_CHARS, wstr, wlen, SvPVX(sv), len, NULL, &use_default);
-    if (use_default) {
+    /* When CP_ACP is CP_UTF8 (set via "Use Unicode UTF-8 for worldwide
+     * language support"), every Unicode string round-trips successfully
+     * and use_default never fires, so the result would be UTF-8 bytes
+     * without the SvUTF8 flag. Force the UTF-8 branch in that case. */
+    if (use_default || GetACP() == CP_UTF8) {
         len = WideCharToMultiByte(CP_UTF8, 0, wstr, wlen, NULL, 0, NULL, NULL);
         sv_grow(sv, len);
         len = WideCharToMultiByte(CP_UTF8, 0, wstr, wlen, SvPVX(sv), len, NULL, NULL);
@@ -258,7 +262,11 @@ my_ansipath(const WCHAR *widename)
     New(0, name, len, char);
     WideCharToMultiByte(CP_ACP, WC_NO_BEST_FIT_CHARS, widename, widelen,
                         name, len, NULL, &use_default);
-    if (use_default) {
+    /* When CP_ACP is CP_UTF8, the conversion above succeeds for every
+     * Unicode path and use_default never fires, but the result would be
+     * UTF-8 bytes returned through what callers expect to be the ANSI
+     * branch. Fall back to the short (8.3) name in that case. */
+    if (use_default || GetACP() == CP_UTF8) {
         DWORD shortlen = GetShortPathNameW(widename, NULL, 0);
         if (shortlen) {
             WCHAR *shortname;

--- a/t/Unicode.t
+++ b/t/Unicode.t
@@ -56,9 +56,12 @@ ok(-f Win32::GetANSIPathName($file));
 ok(opendir(my $dh, Win32::GetANSIPathName($dir)));
 while ($_ = readdir($dh)) {
     next if /^\./;
-    # On Cygwin 1.7 readdir() returns the utf8 representation of the
-    # filename but doesn't turn on the SvUTF8 bit
-    Encode::_utf8_on($_) if $^O eq "cygwin" && $Config{osvers} !~ /^1.5/;
+    # On Cygwin 1.7 and on Windows with CP_ACP == CP_UTF8 ("Use Unicode
+    # UTF-8 for worldwide language support"), readdir() returns the
+    # UTF-8 representation of the filename without setting the SvUTF8
+    # bit, so concatenating $_ with a Unicode $dir would corrupt it.
+    Encode::_utf8_on($_) if Win32::GetACP() == 65001
+        || ($^O eq "cygwin" && $Config{osvers} !~ /^1.5/);
     is($file, Win32::GetLongPathName("$dir\\$_"));
 }
 closedir($dh);


### PR DESCRIPTION
## Summary

Fixes #52 (`t/Unicode.t` failure on systems where the user has enabled "Use Unicode UTF-8 for worldwide language support").

When `GetACP() == CP_UTF8`, the `WideCharToMultiByte(CP_ACP, ..., &use_default)` calls in `wstr_to_sv` and `my_ansipath` always succeed for any Unicode input — `use_default` never fires — so:

- `wstr_to_sv` returns UTF-8 bytes through what callers expect to be the ANSI branch, **without** setting `SvUTF8`. Concatenation with a UTF-8-flagged SV upgrades each byte as Latin-1, producing mojibake (issue #52 subtest 5).
- `my_ansipath` returns the long path as UTF-8 bytes instead of falling back to the short (8.3) name. Re-encoding through `CP_UTF8` in `sv_to_wstr` then produces a path that doesn't match the original file.

The fix detects `GetACP() == CP_UTF8` explicitly in both functions and forces the existing fallback branch.

`t/Unicode.t` subtest 4 (issue #52's other failure) traces to an orthogonal CORE-Perl behavior: `readdir()` returns UTF-8 bytes without setting the `SvUTF8` bit on UTF-8 ACP, identical to the Cygwin 1.7 case the test already works around. The patch extends the existing `Encode::_utf8_on` guard to cover both.

## Test plan

- [x] Reproduce the failure on a UTF-8 ACP system (Win 11 ARM, build 26100.4349, German locale, `chcp` reports 65001) — confirmed subtests 4 and 5 fail before the patch.
- [x] Apply patch, rebuild, rerun: `t/Unicode.t` passes 12/12.
- [x] Run full test suite: 765/766 subtests pass; the one unrelated failure is `t/HttpGetFile.t` test 6 (a separate inverted-SKIP bug introduced in PR #35, to be filed as its own issue).
- [ ] CI — note that GitHub-hosted runners cannot easily flip ACP to 65001 (registry edit + reboot, doesn't survive `Restart-Computer`), so CI continues to exercise the default-ACP path only. The default-ACP code paths are unchanged in this patch (the new `|| GetACP() == CP_UTF8` short-circuits to the existing behavior on default ACP).