### PR TITLE
Revert SvUTF8 flagging in wstr_to_sv / my_ansipath under CP_UTF8 ACP

### DIFF
--- a/Win32.xs
+++ b/Win32.xs
@@ -159,11 +159,7 @@ wstr_to_sv(pTHX_ WCHAR *wstr)
     SV *sv = sv_2mortal(newSV(len));
 
     len = WideCharToMultiByte(CP_ACP, WC_NO_BEST_FIT_CHARS, wstr, wlen, SvPVX(sv), len, NULL, &use_default);
-    /* When CP_ACP is CP_UTF8 (set via "Use Unicode UTF-8 for worldwide
-     * language support"), every Unicode string round-trips successfully
-     * and use_default never fires, so the result would be UTF-8 bytes
-     * without the SvUTF8 flag. Force the UTF-8 branch in that case. */
-    if (use_default || GetACP() == CP_UTF8) {
+    if (use_default) {
         len = WideCharToMultiByte(CP_UTF8, 0, wstr, wlen, NULL, 0, NULL, NULL);
         sv_grow(sv, len);
         len = WideCharToMultiByte(CP_UTF8, 0, wstr, wlen, SvPVX(sv), len, NULL, NULL);
@@ -262,11 +258,7 @@ my_ansipath(const WCHAR *widename)
     New(0, name, len, char);
     WideCharToMultiByte(CP_ACP, WC_NO_BEST_FIT_CHARS, widename, widelen,
                         name, len, NULL, &use_default);
-    /* When CP_ACP is CP_UTF8, the conversion above succeeds for every
-     * Unicode path and use_default never fires, but the result would be
-     * UTF-8 bytes returned through what callers expect to be the ANSI
-     * branch. Fall back to the short (8.3) name in that case. */
-    if (use_default || GetACP() == CP_UTF8) {
+    if (use_default) {
         DWORD shortlen = GetShortPathNameW(widename, NULL, 0);
         if (shortlen) {
             WCHAR *shortname;

--- a/t/Unicode.t
+++ b/t/Unicode.t
@@ -56,12 +56,9 @@ ok(-f Win32::GetANSIPathName($file));
 ok(opendir(my $dh, Win32::GetANSIPathName($dir)));
 while ($_ = readdir($dh)) {
     next if /^\./;
-    # On Cygwin 1.7 and on Windows with CP_ACP == CP_UTF8 ("Use Unicode
-    # UTF-8 for worldwide language support"), readdir() returns the
-    # UTF-8 representation of the filename without setting the SvUTF8
-    # bit, so concatenating $_ with a Unicode $dir would corrupt it.
-    Encode::_utf8_on($_) if Win32::GetACP() == 65001
-        || ($^O eq "cygwin" && $Config{osvers} !~ /^1.5/);
+    # On Cygwin 1.7 readdir() returns the utf8 representation of the
+    # filename but doesn't turn on the SvUTF8 bit
+    Encode::_utf8_on($_) if $^O eq "cygwin" && $Config{osvers} !~ /^1.5/;
     is($file, Win32::GetLongPathName("$dir\\$_"));
 }
 closedir($dh);

--- a/t/Unicode.t
+++ b/t/Unicode.t
@@ -33,6 +33,15 @@ my $cwd  = cwd(); # may be a Cygwin path
 my $dir  = "Foo \x{394}\x{419} Bar \x{5E7}\x{645} Baz";
 my $file = "$dir\\xyzzy \x{394}\x{419} plugh \x{5E7}\x{645}";
 
+# When CP_ACP == CP_UTF8 ("Use Unicode UTF-8 for worldwide language
+# support"), Win32::* functions and readdir() return UTF-8 bytes
+# without setting the SvUTF8 flag. Encode the test's flag-on literals
+# down to the same shape so all comparisons stay byte-vs-byte.
+if (Win32::GetACP() == 65001) {
+    utf8::encode($dir);
+    utf8::encode($file);
+}
+
 sub cleanup {
     chdir($home);
     my $ansi = Win32::GetANSIPathName($file);


### PR DESCRIPTION
## Summary

Reverts PR #53 (commit 256607a) and adapts `t/Unicode.t` to keep passing under CP_UTF8 ACP without the `wstr_to_sv` / `my_ansipath` behavior changes.

## Why

PR #53 detected `GetACP() == CP_UTF8` in `wstr_to_sv` and `my_ansipath` and forced the SvUTF8-flagging branch, so that `Win32::*` results would interoperate cleanly with already-flagged Unicode strings. The same proposal extended to core Perl in [Perl/perl5#24416](https://github.com/Perl/perl5/pull/24416) drew principled pushback that applies here too.

The read/write asymmetry is real:

- `Win32::*` results that get SvUTF8 set under CP_UTF8 ACP corrupt downstream concatenation with anything that holds UTF-8 bytes without the flag — `$ENV`, `readdir`, file content, source without `use utf8`, anything that round-trips through OS APIs.
- The user surface that benefits from the flag (people who deliberately interpolate `Win32::*` output with already-flagged Unicode literals) is small, and they can flag results explicitly with `Encode::_utf8_on` at the call site.
- The user surface that gets hurt by the flag (anyone whose output ever touches the unflagged-bytes ecosystem) is large and has no obvious self-fix.

Risk-vs-reward favors reverting and matching core Perl's bag-of-bytes contract under CP_UTF8 ACP. The companion PR #56 (which extended the same flagging policy to other XS sites) was closed unmerged for the same reason.

`my_ansipath`: under CP_UTF8 ACP `use_default` never fires, so the function returns the long UTF-8 path bytes — which IS the correct ANSI path on a CP_UTF8 system. PR #53's fall-back to the 8.3 short name loses information for no concrete gain on this configuration. Reverted.

## Test changes

After the revert, every `Win32::*` function returns flag-off UTF-8 bytes under CP_UTF8 ACP — the same shape `readdir()` already returned. `t/Unicode.t` builds `$dir` and `$file` from `\x{NNNN}` literals above 0xFF, which forces SvUTF8-flagged storage. `eq` comparisons against the flag-off `Win32::*` results would Latin-1-upgrade the bytes and produce mojibake.

Downgrade `$dir` and `$file` to flag-off UTF-8 bytes once at the top of the test under CP_UTF8 ACP, so every comparison stays byte-vs-byte. Legacy ACP is unchanged.

## Test plan

- [x] Full test suite on UTF-8 ACP German Windows VM (Strawberry 5.42, build 26100.4349) — 766/766 pass.
- [ ] CI Strawberry matrix (legacy ACP) — `t/Unicode.t` still exercises `wstr_to_sv`'s `use_default` fallback for codepoints not representable in CP_ACP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)