### PR TITLE
Add Cygwin -DDEBUGGING CI job and fix HttpGetFile last-error clobbering

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,3 +9,54 @@ on:
 jobs:
   test:
     uses: perl-libwin32/.github/.github/workflows/test.yml@v2
+
+  # t/HttpGetFile.t fails when perl is built with -DDEBUGGING on Cygwin
+  # (https://github.com/perl-libwin32/win32/issues/62).  The reusable
+  # workflow's cygwin job tests Cygwin's packaged perl, a non-debugging
+  # build, so this job builds perl from source with the Configure flags
+  # perl5 core CI uses.
+  cygwin-debugging:
+    name: Cygwin -DDEBUGGING
+    runs-on: windows-latest
+    timeout-minutes: 60
+    env:
+      PERL_VERSION: 5.45.1
+    defaults:
+      run:
+        shell: C:\cygwin\bin\bash.exe --login --norc -eo pipefail -o igncr '{0}'
+    steps:
+      - name: Preserve LF line endings on checkout
+        shell: pwsh
+        run: git config --global core.autocrlf input
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: 'Enable 8.3 name creation on D: (the GHA worker volume)'
+        shell: pwsh
+        run: |
+          fsutil 8dot3name set D: 0
+          fsutil 8dot3name query D:
+      - uses: cygwin/cygwin-install-action@711d29f3da23c9f4a1798e369a6f01198c13b11a # v6.1
+        with:
+          packages: >-
+            cygwin-devel
+            gcc-core
+            make
+            w32api-headers
+            binutils
+            libcrypt-devel
+            git
+      - name: Build -DDEBUGGING perl
+        run: |
+          git clone --depth 1 --branch "v$PERL_VERSION" https://github.com/Perl/perl5.git ~/perl5
+          cd ~/perl5
+          ./Configure -des -Dusedevel -Doptimize=-g -DDEBUGGING -Dman1dir=none -Dman3dir=none -Dprefix="$HOME/dbgperl"
+          make -j2
+          make install
+      - name: Build and test Win32
+        run: |
+          cd "$(cygpath --unix "$GITHUB_WORKSPACE")"
+          perl="$HOME/dbgperl/bin/perl$PERL_VERSION"
+          "$perl" -V
+          "$perl" -V | grep --quiet --word-regexp DEBUGGING
+          "$perl" Makefile.PL
+          make
+          make test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,7 @@ jobs:
           packages: >-
             cygwin-devel
             gcc-core
+            gcc-g++
             make
             w32api-headers
             binutils

--- a/Win32.xs
+++ b/Win32.xs
@@ -1977,7 +1977,7 @@ XS(w32_HttpGetFile)
      */
     if (bAborted) {
         if (bHttpError) {
-            SetLastError(dwHttpStatusCode + 1000000000);
+            error = dwHttpStatusCode + 1000000000;
         }
         else {
             DWORD msgFlags = bFileError
@@ -1995,22 +1995,31 @@ XS(w32_HttpGetFile)
                                 NULL)) {
                 wcsncpy(msgbuf, L"unable to format error message", ONE_K_BUFSIZE - 1);
             }
-            SetLastError(error);
         }
     }
 
+    /* Set the last error only after building the return values.
+     * wstr_to_sv() calls WideCharToMultiByte() and allocates SVs, either
+     * of which may clobber it (GH issue #62, seen on Cygwin DEBUGGING builds).
+     */
     if (GIMME_V == G_SCALAR) {
         EXTEND(SP, 1);
         ST(0) = !bAborted ? &PL_sv_yes : &PL_sv_no;
+        if (bAborted)
+            SetLastError(error);
         XSRETURN(1);
     }
     else if (GIMME_V == G_ARRAY) {
         EXTEND(SP, 2);
         ST(0) = !bAborted ? &PL_sv_yes : &PL_sv_no;
         ST(1) = wstr_to_sv(aTHX_ msgbuf);
+        if (bAborted)
+            SetLastError(error);
         XSRETURN(2);
     }
     else {
+        if (bAborted)
+            SetLastError(error);
         XSRETURN_EMPTY;
     }
 }


### PR DESCRIPTION
Adds a Cygwin -DDEBUGGING CI job and fixes the bug it was built to catch: t/HttpGetFile.t failing on Cygwin -DDEBUGGING perls (#62).

- **Add Cygwin -DDEBUGGING CI job** — Cygwin's packaged perl is a non-debugging build, so the existing cygwin job could not catch #62. The new job builds perl 5.45.1 from source with the Configure flags perl5 core CI uses and runs the module tests against it (about 14 minutes).
- **Add gcc-g++ to Cygwin -DDEBUGGING packages** — perl's Cygwin build links with g++; without Cygwin's g++ installed, the runner's MinGW g++ shadowed it and the link failed on the Cygwin-only -ldl and -lcrypt.
- **Set the last error after building HttpGetFile return values** — in list context wstr_to_sv() ran after SetLastError(), and its WideCharToMultiByte() calls and SV allocation can clobber the thread's last error. Setting the error code last, in all calling contexts, closes the window inside the XSUB.

Verification: without the fix, the new job failed on exactly test 7 of t/HttpGetFile.t ([run 31312637060](https://github.com/perl-libwin32/win32/actions/runs/31312637060)), matching sisyphus's reduction in #62; with it, all 764 subtests pass ([run 31315214096](https://github.com/perl-libwin32/win32/actions/runs/31315214096)). The other eight jobs stayed green throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)