### PR TITLE
gdb watchpoint experiment for the issue #62 residual clobber (not for merge)

### DIFF
--- a/.github/workflows/issue-62-gdb-trace.yml
+++ b/.github/workflows/issue-62-gdb-trace.yml
@@ -11,11 +11,23 @@ on:
 
 jobs:
   gdb-trace:
-    name: Watchpoint trace on Cygwin -DDEBUGGING
+    name: Watchpoint trace (${{ matrix.name }})
     runs-on: windows-latest
     timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: debugging
+            optimize: '-g'
+            debug_flag: '-DDEBUGGING'
+          - name: optimized
+            optimize: '-O2 -g'
+            debug_flag: ''
     env:
       PERL_VERSION: 5.45.1
+      OPTIMIZE: ${{ matrix.optimize }}
+      DEBUG_FLAG: ${{ matrix.debug_flag }}
     defaults:
       run:
         shell: C:\cygwin\bin\bash.exe --login --norc -eo pipefail -o igncr '{0}'
@@ -41,11 +53,12 @@ jobs:
             libcrypt-devel
             git
             gdb
+            cygwin-debuginfo
       - name: Build -DDEBUGGING perl
         run: |
           git clone --depth 1 --branch "v$PERL_VERSION" https://github.com/Perl/perl5.git ~/perl5
           cd ~/perl5
-          ./Configure -des -Dusedevel -Doptimize=-g -DDEBUGGING -Dman1dir=none -Dman3dir=none -Dprefix="$HOME/dbgperl"
+          ./Configure -des -Dusedevel -Doptimize="$OPTIMIZE" $DEBUG_FLAG -Dman1dir=none -Dman3dir=none -Dprefix="$HOME/dbgperl"
           make -j2
           make install
       - name: Build Win32

--- a/.github/workflows/issue-62-gdb-trace.yml
+++ b/.github/workflows/issue-62-gdb-trace.yml
@@ -1,0 +1,69 @@
+name: issue-62-gdb-trace
+
+# Temporary experiment for issue #62's residual bar-style clobber: find
+# which Windows call zeroes the TEB's LastErrorValue during the one
+# libc free() in bar's window. Lives only on this branch; not for merge.
+
+on:
+  push:
+    branches: [issue-62-gdb-trace]
+  workflow_dispatch:
+
+jobs:
+  gdb-trace:
+    name: Watchpoint trace on Cygwin -DDEBUGGING
+    runs-on: windows-latest
+    timeout-minutes: 60
+    env:
+      PERL_VERSION: 5.45.1
+    defaults:
+      run:
+        shell: C:\cygwin\bin\bash.exe --login --norc -eo pipefail -o igncr '{0}'
+    steps:
+      - name: Preserve LF line endings on checkout
+        shell: pwsh
+        run: git config --global core.autocrlf input
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: 'Enable 8.3 name creation on D: (the GHA worker volume)'
+        shell: pwsh
+        run: |
+          fsutil 8dot3name set D: 0
+          fsutil 8dot3name query D:
+      - uses: cygwin/cygwin-install-action@711d29f3da23c9f4a1798e369a6f01198c13b11a # v6.1
+        with:
+          packages: >-
+            cygwin-devel
+            gcc-core
+            gcc-g++
+            make
+            w32api-headers
+            binutils
+            libcrypt-devel
+            git
+            gdb
+      - name: Build -DDEBUGGING perl
+        run: |
+          git clone --depth 1 --branch "v$PERL_VERSION" https://github.com/Perl/perl5.git ~/perl5
+          cd ~/perl5
+          ./Configure -des -Dusedevel -Doptimize=-g -DDEBUGGING -Dman1dir=none -Dman3dir=none -Dprefix="$HOME/dbgperl"
+          make -j2
+          make install
+      - name: Build Win32
+        run: |
+          cd "$(cygpath --unix "$GITHUB_WORKSPACE")"
+          "$HOME/dbgperl/bin/perl$PERL_VERSION" Makefile.PL
+          make
+      - name: Baseline run of bug.p
+        run: |
+          cd "$(cygpath --unix "$GITHUB_WORKSPACE")"
+          "$HOME/dbgperl/bin/perl$PERL_VERSION" -Mblib maint/issue-62-trace/bug.p
+      - name: Watchpoint trace
+        run: |
+          cd "$(cygpath --unix "$GITHUB_WORKSPACE")"
+          gdb --batch --command=maint/issue-62-trace/watch-lasterror.gdb \
+              --args "$HOME/dbgperl/bin/perl$PERL_VERSION" -Mblib maint/issue-62-trace/bug.p
+      - name: Control run with malloc trim disabled
+        run: |
+          cd "$(cygpath --unix "$GITHUB_WORKSPACE")"
+          gdb --batch --command=maint/issue-62-trace/no-trim.gdb \
+              --args "$HOME/dbgperl/bin/perl$PERL_VERSION" -Mblib maint/issue-62-trace/bug.p

--- a/maint/issue-62-trace/bug.p
+++ b/maint/issue-62-trace/bug.p
@@ -1,0 +1,30 @@
+# sisyphus's reducer from
+# https://github.com/perl-libwin32/win32/issues/62#issuecomment-5229995195
+use strict;
+use warnings;
+use Win32;
+
+my @args = ('nonesuch://example.com', 'NUL:');
+my $LastError;
+
+foo(@args);
+bar(@args);
+baz(@args);
+
+sub foo {
+    my $ok = Win32::HttpGetFile(@_);
+    $LastError = Win32::GetLastError();
+    print "foo last error: $LastError\n";
+}
+
+sub bar {
+    my($ok) = Win32::HttpGetFile(@_);
+    $LastError = Win32::GetLastError();
+    print "bar last error: $LastError\n";
+}
+
+sub baz {
+    my ($ok, $message) = Win32::HttpGetFile(@_);
+    $LastError = Win32::GetLastError();
+    print "baz last error: $LastError\n";
+}

--- a/maint/issue-62-trace/no-trim.gdb
+++ b/maint/issue-62-trace/no-trim.gdb
@@ -3,6 +3,9 @@
 # the clobber goes through dlfree's sys_trim -> sbrk -> VirtualFree path.
 set pagination off
 set confirm off
+# Win32.dll is loaded at runtime by DynaLoader, so the breakpoint must
+# stay pending until then.
+set breakpoint pending on
 break w32_HttpGetFile
 run
 

--- a/maint/issue-62-trace/no-trim.gdb
+++ b/maint/issue-62-trace/no-trim.gdb
@@ -1,0 +1,12 @@
+# Control run: disable dlmalloc heap trimming before any HttpGetFile
+# call, then let bug.p print its own results. If bar reports 12006 here,
+# the clobber goes through dlfree's sys_trim -> sbrk -> VirtualFree path.
+set pagination off
+set confirm off
+break w32_HttpGetFile
+run
+
+# dlmalloc mallopt parameter -1 is M_TRIM_THRESHOLD; INT_MAX disables trim.
+print (int) mallopt (-1, 2147483647)
+delete
+continue

--- a/maint/issue-62-trace/watch-lasterror.gdb
+++ b/maint/issue-62-trace/watch-lasterror.gdb
@@ -15,9 +15,12 @@ run
 python
 import re
 out = gdb.execute("info w32 thread-information-block", to_string=True)
-m = re.search(r"0x[0-9a-fA-F]+", out)
+gdb.write("info w32 thread-information-block:\n" + out + "\n")
+# The first short hex number is the thread id; the TEB address is the
+# first long one.
+m = re.search(r"0x[0-9a-fA-F]{7,}", out)
 if not m:
-    gdb.write("cannot find TEB address in:\n" + out + "\n")
+    gdb.write("cannot find TEB address above\n")
     gdb.execute("quit 2")
 gdb.execute("set $lasterr = (unsigned int *)(" + m.group(0) + " + 0x68)")
 end

--- a/maint/issue-62-trace/watch-lasterror.gdb
+++ b/maint/issue-62-trace/watch-lasterror.gdb
@@ -16,13 +16,13 @@ python
 import re
 out = gdb.execute("info w32 thread-information-block", to_string=True)
 gdb.write("info w32 thread-information-block:\n" + out + "\n")
-# The first short hex number is the thread id; the TEB address is the
-# first long one.
-m = re.search(r"0x[0-9a-fA-F]{7,}", out)
+# Parse the labeled TEB base address; bare-hex heuristics matched the
+# thread id once and current_seh's zeros another time.
+m = re.search(r"linear_address_tib\s+is\s+(0x[0-9a-fA-F]+)", out)
 if not m:
     gdb.write("cannot find TEB address above\n")
     gdb.execute("quit 2")
-gdb.execute("set $lasterr = (unsigned int *)(" + m.group(0) + " + 0x68)")
+gdb.execute("set $lasterr = (unsigned int *)(" + m.group(1) + " + 0x68)")
 end
 printf "TEB LastErrorValue at %p, value now: %u\n", $lasterr, *$lasterr
 

--- a/maint/issue-62-trace/watch-lasterror.gdb
+++ b/maint/issue-62-trace/watch-lasterror.gdb
@@ -34,6 +34,36 @@ commands
   continue
 end
 
+# Entry breakpoints unwind cleanly past the sigfe trampoline, naming the
+# true callers the watchpoint backtraces elide. Active only during bar's
+# window; breakpoint 5 disables them when the window closes.
+break free
+commands
+  silent
+  printf "\n*** free() entered ***\n"
+  bt 6
+  continue
+end
+
+break pthread_getspecific
+commands
+  silent
+  printf "\n*** pthread_getspecific entered ***\n"
+  info args
+  bt 8
+  continue
+end
+
+break w32_GetLastError
+commands
+  silent
+  printf "\n--- window closed (Win32::GetLastError read) ---\n"
+  disable 3
+  disable 4
+  disable 5
+  continue
+end
+
 commands 1
   silent
   printf "\n--- list-context SetLastError site reached again ---\n"

--- a/maint/issue-62-trace/watch-lasterror.gdb
+++ b/maint/issue-62-trace/watch-lasterror.gdb
@@ -3,6 +3,9 @@
 # Every later write prints a backtrace naming the code that changed it.
 set pagination off
 set confirm off
+# Win32.dll is loaded at runtime by DynaLoader, so the breakpoint must
+# stay pending until then.
+set breakpoint pending on
 
 # Win32.xs:2018 is the XSRETURN(2) in the G_ARRAY branch, one line after
 # SetLastError(error); the first hit is bar's call (foo takes G_SCALAR).
@@ -12,8 +15,11 @@ run
 python
 import re
 out = gdb.execute("info w32 thread-information-block", to_string=True)
-teb = re.search(r"0x[0-9a-fA-F]+", out).group(0)
-gdb.execute("set $lasterr = (unsigned int *)(" + teb + " + 0x68)")
+m = re.search(r"0x[0-9a-fA-F]+", out)
+if not m:
+    gdb.write("cannot find TEB address in:\n" + out + "\n")
+    gdb.execute("quit 2")
+gdb.execute("set $lasterr = (unsigned int *)(" + m.group(0) + " + 0x68)")
 end
 printf "TEB LastErrorValue at %p, value now: %u\n", $lasterr, *$lasterr
 

--- a/maint/issue-62-trace/watch-lasterror.gdb
+++ b/maint/issue-62-trace/watch-lasterror.gdb
@@ -1,0 +1,34 @@
+# Hardware watchpoint on the TEB's LastErrorValue (TEB+0x68 on x64),
+# armed at the first list-context SetLastError in w32_HttpGetFile.
+# Every later write prints a backtrace naming the code that changed it.
+set pagination off
+set confirm off
+
+# Win32.xs:2018 is the XSRETURN(2) in the G_ARRAY branch, one line after
+# SetLastError(error); the first hit is bar's call (foo takes G_SCALAR).
+break Win32.xs:2018
+run
+
+python
+import re
+out = gdb.execute("info w32 thread-information-block", to_string=True)
+teb = re.search(r"0x[0-9a-fA-F]+", out).group(0)
+gdb.execute("set $lasterr = (unsigned int *)(" + teb + " + 0x68)")
+end
+printf "TEB LastErrorValue at %p, value now: %u\n", $lasterr, *$lasterr
+
+watch -l *$lasterr
+commands
+  silent
+  printf "\n=== LastErrorValue -> %u ===\n", *$lasterr
+  bt 12
+  continue
+end
+
+commands 1
+  silent
+  printf "\n--- list-context SetLastError site reached again ---\n"
+  continue
+end
+
+continue


### PR DESCRIPTION
Experiment branch chasing the one part of #62 the fix in #63 could not cover: `my ($ok) = Win32::HttpGetFile(...)` still loses the last error on Cygwin -DDEBUGGING builds, after the XSUB has already returned.

The branch-only workflow builds perl 5.45.1 from source on Cygwin (matrix: `-DDEBUGGING -g` and `-O2` without DEBUGGING), runs sisyphus's reducer from #62 under gdb with a hardware watchpoint on the TEB's LastErrorValue, and backtraces every write. A control run disables dlmalloc trimming via mallopt. Later commits add cygwin1.dll debug symbols and entry breakpoints on free and pthread_getspecific scoped to the failing statement's window.

The full report is posted on #62: https://github.com/perl-libwin32/win32/issues/62#issuecomment-5240317628 (per-run logs on this branch's Actions). Draft on purpose: never merge, delete the branch when the investigation closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
