### PR TITLE
Force LF line endings in every checkout

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
Releases 0.60 through 0.63 shipped CPAN tarballs with CRLF line endings. The release workflow runs on a Windows runner whose git defaults to core.autocrlf=true, so checkout converts text files and "make dist" packages the converted tree. Force LF in every checkout so the release runner, CI, and Windows contributors all get the same bytes.

Verified with `git -c core.autocrlf=true clone`: master checks out all files CRLF, this branch none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)